### PR TITLE
use correct framework

### DIFF
--- a/CP.VPOS/CP.VPOS.csproj
+++ b/CP.VPOS/CP.VPOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks Condition="'$(LibraryFrameworks)'==''">net40;net45;netstandard2.0;netstandard2.1;net50;net60;net70;net80</TargetFrameworks>
+		<TargetFrameworks Condition="'$(LibraryFrameworks)'==''">net40;net45;netstandard2.0;netstandard2.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
 		<TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks)</TargetFrameworks>
 		<Version>1.8.4</Version>
 		<Authors>Cem Pehlivan</Authors>
@@ -36,45 +36,10 @@
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
 		<Reference Include="System.Net.Http" />
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net80'">
-		<PackageReference Include="System.ComponentModel.Annotations">
-			<Version>5.0.0</Version>
-		</PackageReference>
+	<ItemGroup Condition="'$(TargetFramework)' != 'net40'">
+		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks

also unified a redundant reference