### PR TITLE
Nestpay 3d ödeme yöntemi için storetype değiştirilebilir olması

### DIFF
--- a/CP.VPOS/Banks/NestpayAbstract.cs
+++ b/CP.VPOS/Banks/NestpayAbstract.cs
@@ -225,7 +225,7 @@ namespace CP.VPOS.Banks
                 { "okUrl", request.payment3D.returnURL },
                 { "failUrl", request.payment3D.returnURL },
                 { "rnd", Helpers.FoundationHelper.time().ToString()},
-                { "storetype", "3d_pay" },
+                { "storetype", auth.storeType },
                 { "lang", "tr" },
                 { "currency", ((int)request.saleInfo.currency).ToString() },
                 { "installment", installment },

--- a/CP.VPOS/Models/VirtualPOSAuth.cs
+++ b/CP.VPOS/Models/VirtualPOSAuth.cs
@@ -35,6 +35,11 @@ namespace CP.VPOS.Models
         public string merchantStorekey { get; set; }
 
         /// <summary>
+        /// Ödeme yöntemi,3D,3D_PAY,3D_PAY_HOSTING gibi yöntemler belirlenebilir. Boş geçilmesi halinde varsayılan 3D_PAY'dir
+        /// </summary>
+        public string storeType { get; set; } = "3d_pay";
+
+        /// <summary>
         /// Test ortamı ise true gönderilmelidir.
         /// </summary>
         public bool testPlatform { get; set; }


### PR DESCRIPTION
Nestpay 3d ödeme yöntemlerinde 3d,3d_pay,3d_pay_hosting yöntemlerinin seçilmesi. Eğer tanımlama yapılmadıysa eskisi gibi 3d_pay olarak ilerlenebilir